### PR TITLE
Align to unprocessed provider's classifier output

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -48,9 +48,9 @@ const App = () => {
     <StyledResult>
       <div>
         <span>Response is:</span>
-        {result && result[0].summary_text}
+        {result && result.summary.summary_text}
         {result &&
-          result[1].summary_list.map(({ label, score }) => (
+          result.emotion.map(({ label, score }) => (
             <div>
               <span>{label}:</span>
               <span>{score}</span>

--- a/server/specs/server.yaml
+++ b/server/specs/server.yaml
@@ -24,27 +24,24 @@ paths:
           content:
             application/json:
                 schema:
-                    $ref: '#/components/schemas/TextClassification'
+                    $ref: '#/components/schemas/TextClassificationResult'
                 example:
-                    results:
-                        -
-                            classifier_id: 'distilbart-cnn-12-6'
-                            summary_text:
-                                The tower is 324 metres (1,063 ft) tall, about the same height as an 81-storey building . 
-                                It was the first structure to reach a height of 300 metres . It is now taller than the 
-                                Chrysler Building in New York City
-                        -
-                            classifier_id: 'bert-base-uncased-emotion'
-                            summary_list:
-                                -
-                                    label: 'love'
-                                    score: 0.005923508666455746
-                                -
-                                    label: 'joy'
-                                    score: 0.38369229435920715
-                                -
-                                    label: 'surprise'
-                                    score: 0.6015767455101013
+                    emotion:
+                      -
+                          label: 'love'
+                          score: 0.005923508666455746
+                      -
+                          label: 'joy'
+                          score: 0.38369229435920715
+                      -
+                          label: 'surprise'
+                          score: 0.6015767455101013
+                    summary:
+                      summary_text: >
+                          The tower is 324 metres (1,063 ft) tall, about the same height as an 81-storey building . 
+                          It was the first structure to reach a height of 300 metres . It is now taller than the 
+                          Chrysler Building in New York City
+ 
         '413':
           description: Payload too large
           content:
@@ -85,30 +82,43 @@ paths:
 
 components:
   schemas:
-    TextClassification:
+    TextClassificationResult:
       type: object
       required:
-        - results
+        - emotion
+        - summary
       properties:
-        results:
-            type: array
-            minItems: 1
-            items:
-                $ref: '#/components/schemas/TextClassificationResult'
-    TextClassificationResult:
-        type: object
-        required:
-          - classifier_id
-        properties:
-            classifier_id:
-                type: string
-            summary_text:
+          summary:
+            type: object
+            properties:
+              emotion:
+                type: array
+                minItems: 6
+                items:
+                  $ref: '#/components/schemas/EmotionResult'
+              summary_text:
                 type: string
                 maxLength: 2048
-            summary_list:
+                
+    EmotionResult:
+      type: object
+      required:
+        - classifier_id
+      properties:
+        summary:
+          type: object
+            properties:
+              summary_text:
+                type: string
+                maxLength: 2048
+              emotion:
                 type: array
                 items:
-                    type: object
+                  type: object
+                  properties:
+                    label: string
+                    score: number
+
     Error:
       type: object
       required:


### PR DESCRIPTION
It'd would be easier to pass unprocessed classifier output directly to frontend. Example schema can be checked in [provider/test/the_queen_output.json](https://github.com/golemfactory/yagna-service-poc/blob/master/provider/test/the_queen_output.json)

Example output from classifier
```
 cat provider/test/the_queen_output.json | jq
{
  "emotion": [
    {
      "label": "sadness",
      "score": 0.19551274180412292
    },
    {
      "label": "joy",
      "score": 0.6668532490730286
    },
    {
      "label": "love",
      "score": 0.061145614832639694
    },
    {
      "label": "anger",
      "score": 0.051483768969774246
    },
    {
      "label": "fear",
      "score": 0.02209818735718727
    },
    {
      "label": "surprise",
      "score": 0.0029064537957310677
    }
  ],
  "summary": {
    "summary_text": " The Queen hosted a ceremony in which the Earl Peel stood down as Lord Chamberlain . She accepted her former aide's wand and office insignia at a private event at Windsor Castle . The duke's funeral will take place at Windsor on Saturday . A royal official said members of the family would continue to undertake engagements ."
  }
}
```